### PR TITLE
Improve experience section layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -140,94 +140,81 @@ h2 {
 /* Experience Timeline */
 .timeline {
     position: relative;
-    max-width: 800px;
+    max-width: 1000px;
     margin: 0 auto;
+    padding-left: 2.5rem;
 }
 
 .timeline::after {
     content: '';
     position: absolute;
-    width: 2px;
-    background-color: var(--secondary-color);
+    width: 1px;
+    background: linear-gradient(180deg, transparent, var(--secondary-color), transparent);
     top: 0;
     bottom: 0;
-    left: 50%;
-    margin-left: -1px;
+    left: 18px;
 }
 
 .timeline-item {
-    padding: 1rem 3rem;
+    padding: 1.5rem 0 1.5rem 2.5rem;
     position: relative;
-    width: 50%;
-}
-
-.timeline-item:nth-child(odd) {
-    left: 0;
-}
-
-.timeline-item:nth-child(even) {
-    left: 50%;
+    width: 100%;
 }
 
 .timeline-dot {
     content: '';
     position: absolute;
-    width: 16px;
-    height: 16px;
+    width: 12px;
+    height: 12px;
     background-color: var(--accent-color);
     border-radius: 50%;
-    top: 24px;
+    top: 34px;
     z-index: 1;
-}
-
-.timeline-item:nth-child(odd) .timeline-dot {
-    right: -8px;
-}
-
-.timeline-item:nth-child(even) .timeline-dot {
-    left: -8px;
+    left: 12px;
+    box-shadow: 0 0 0 6px rgba(0, 123, 255, 0.15);
 }
 
 .timeline-date {
-    position: absolute;
-    top: 22px;
-    font-size: 0.9rem;
+    position: static;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background-color: rgba(255, 255, 255, 0.06);
+    font-size: 0.85rem;
     color: var(--subtle-text-color);
     font-family: 'JetBrains Mono', monospace;
-}
-
-.timeline-item:nth-child(odd) .timeline-date {
-    left: 100%;
-    margin-left: 3rem;
-    text-align: left;
-}
-
-.timeline-item:nth-child(even) .timeline-date {
-    right: 100%;
-    margin-right: 3rem;
-    text-align: right;
+    margin-bottom: 1rem;
+    letter-spacing: 0.02em;
 }
 
 .timeline-content {
-    padding: 1.5rem;
-    background-color: var(--secondary-color);
-    border-radius: 8px;
+    padding: 2rem;
+    background: linear-gradient(135deg, rgba(42, 42, 42, 0.92), rgba(32, 32, 32, 0.92));
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 }
 
 .timeline-content h3 {
     margin-top: 0;
-    font-size: 1.2rem;
+    font-size: 1.35rem;
+    margin-bottom: 0.5rem;
 }
 
 .timeline-content p {
-    font-size: 0.9rem;
+    font-size: 1rem;
     color: var(--subtle-text-color);
+    margin-top: 0;
+    margin-bottom: 1rem;
 }
 
 .timeline-content ul {
     padding-left: 1.2rem;
-    font-size: 0.95rem;
-    line-height: 1.5;
+    font-size: 1rem;
+    line-height: 1.7;
+    margin: 0;
 }
 
 /* Skills Grid */
@@ -317,28 +304,16 @@ footer {
     }
 
     .timeline::after {
-        left: 20px;
+        left: 16px;
     }
 
     .timeline-item {
         width: 100%;
-        padding-left: 50px;
-        padding-right: 1rem;
-    }
-
-    .timeline-item:nth-child(even) {
-        left: 0%;
+        padding-left: 2.5rem;
+        padding-right: 0;
     }
 
     .timeline-dot {
-        left: 12px;
-    }
-
-    .timeline-date {
-        position: relative;
-        top: auto;
-        left: auto;
-        text-align: left !important;
-        margin-bottom: 0.5rem;
+        left: 10px;
     }
 }


### PR DESCRIPTION
### Motivation
- Make the Experience section more visual and prominent so job history reads clearly and feels less narrow. 
- Align the layout with the provided mocks by using a left rail and larger, card-like entries for each job. 
- Preserve all existing content and contact information while only changing the visual presentation. 
- Improve mobile stacking and spacing so the timeline is coherent and readable on small screens. 

### Description
- Restyled the timeline in `styles.css` to use a left rail and full-width cards by changing `.timeline` to a wider container and adding left padding. 
- Converted the center line to a subtle left rail and transformed date labels into pill-style elements with `border-radius` and muted background. 
- Turned timeline items into full-width cards with increased `padding`, a `linear-gradient` background, larger typography, rounded corners, border and shadow to boost contrast and visual weight. 
- Adjusted the timeline dot size and added a glow, and improved responsive rules so mobile uses stacked cards with updated left offsets. 

### Testing
- Started a local static server with `python -m http.server` and the server ran successfully. 
- Executed a Playwright script to capture screenshots which produced `artifacts/experience-desktop.png` and `artifacts/experience-mobile.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950256c548483239418099377803a44)