### PR TITLE
Use remote university logo links; refine skills filter; add Cerebras role; update contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,9 +154,9 @@
           <div class="experience-card rounded-2xl p-5 shadow-soft">
             <p class="mono text-xs uppercase tracking-[0.2em] text-slate-400">Focus</p>
             <ul class="mt-3 space-y-3 text-sm text-slate-300">
-              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>AI training & inference platforms with production-grade control planes</li>
+              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>AI training & inference platforms with cluster orchestration and control planes</li>
+              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Kubernetes engineering (controllers, reconcilers, and advanced platform workflows)</li>
               <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Distributed systems, event-driven architectures, and high-scale data pipelines</li>
-              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Operational excellence, observability, and resilient tooling</li>
             </ul>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
           <div class="experience-card rounded-2xl p-5 shadow-soft">
             <p class="mono text-xs uppercase tracking-[0.2em] text-slate-400">Focus</p>
             <ul class="mt-3 space-y-3 text-sm text-slate-300">
-              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>AI training & inference platforms with Kubernetes-style control planes</li>
+              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>AI training & inference platforms with production-grade control planes</li>
               <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Distributed systems, streaming, and high-scale data pipelines</li>
               <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Operational excellence, observability, and resilient tooling</li>
             </ul>
@@ -170,14 +170,6 @@
         <p class="text-slate-300 leading-relaxed">
           Senior engineer focused on AI platform engineering, backend systems, and cloud orchestration. Currently pursuing a Master of Computer Science in Artificial Intelligence at UT Austin (2025–2027, expected) while building production control planes for AI training and inference.
         </p>
-        <div class="text-slate-300 leading-relaxed space-y-2">
-          <p>Completed coursework:</p>
-          <ul class="list-disc list-inside space-y-1">
-            <li>Deep Learning</li>
-            <li>Advanced Deep Learning</li>
-            <li>Ethics in AI</li>
-          </ul>
-        </div>
         <p class="text-slate-300 leading-relaxed">
           Looking for: senior or staff software engineering roles leading complex AI platform initiatives and mentoring teams.
         </p>
@@ -508,6 +500,7 @@
                 <h3 class="text-sm font-semibold text-slate-100">The University of Texas at Austin</h3>
                 <p class="text-xs text-slate-400">Master of Science (MSc), Computer Science · Specialization: Artificial Intelligence</p>
                 <p class="text-xs text-slate-400">2025 – 2027 (Expected)</p>
+                <p class="text-xs text-slate-400">Coursework: Deep Learning, Advanced Deep Learning, Ethics in AI</p>
               </div>
               <img src="https://raw.githubusercontent.com/abrelsfo/sportsJSON/master/collegeFootball/logos/texas.png" alt="University of Texas at Austin logo" class="h-8 w-auto opacity-60 grayscale" />
             </div>

--- a/index.html
+++ b/index.html
@@ -86,23 +86,16 @@
     .timeline {
       position: relative;
     }
-    .timeline::before {
-      content: '';
-      position: absolute;
-      top: 0.5rem;
-      bottom: 0.5rem;
-      left: 0.5rem;
-      width: 1px;
-      background: rgba(148, 163, 184, 0.18);
-    }
     .timeline-item {
       position: relative;
-      padding-left: 2.75rem;
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: minmax(220px, 40%) minmax(0, 60%);
     }
     .timeline-node {
       position: absolute;
-      left: 0.25rem;
-      top: 1.2rem;
+      left: 0.5rem;
+      top: 1.15rem;
       width: 0.75rem;
       height: 0.75rem;
       border-radius: 999px;
@@ -110,8 +103,19 @@
       box-shadow: 0 0 0 4px rgba(15, 17, 25, 1);
     }
     .timeline-anchor {
+      position: relative;
+      padding-left: 2.75rem;
       display: grid;
       gap: 0.35rem;
+    }
+    .timeline-anchor::before {
+      content: '';
+      position: absolute;
+      top: 0.5rem;
+      bottom: 0.5rem;
+      left: 0.85rem;
+      width: 1px;
+      background: rgba(148, 163, 184, 0.18);
     }
     .timeline-company {
       font-size: clamp(1.4rem, 1.1rem + 1vw, 2rem);
@@ -131,20 +135,25 @@
       color: #cbd5f5;
     }
     .timeline-bullets {
-      margin-top: 0.75rem;
       font-size: 0.95rem;
       color: #cbd5f5;
       line-height: 1.6;
     }
+    .timeline-details {
+      padding-top: 0.1rem;
+    }
     @media (max-width: 640px) {
-      .timeline::before {
-        left: 0.3rem;
-      }
       .timeline-item {
-        padding-left: 2.25rem;
+        grid-template-columns: 1fr;
       }
       .timeline-node {
-        left: 0.05rem;
+        left: 0.5rem;
+      }
+      .timeline-anchor {
+        padding-left: 2.25rem;
+      }
+      .timeline-anchor::before {
+        left: 0.6rem;
       }
       .timeline-meta {
         font-size: 0.9rem;
@@ -363,23 +372,25 @@
                 <span>Toronto ON</span>
               </div>
             </div>
-            <ul class="collapsed-bullets timeline-bullets space-y-2">
+            <div class="timeline-details">
+              <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
                 <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
               </ul>
-            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-              Show more
-              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-            </button>
-            <div class="accordion-content hidden pt-3">
-              <ul class="expanded-bullets timeline-bullets space-y-2">
-                <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
-                <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
-              </ul>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Controllers</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Scheduling</span>
+              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+                Show more
+                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+              </button>
+              <div class="accordion-content hidden pt-3">
+                <ul class="expanded-bullets timeline-bullets space-y-2">
+                  <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
+                  <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
+                </ul>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Controllers</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Scheduling</span>
+                </div>
               </div>
             </div>
           </article>
@@ -395,24 +406,26 @@
                 <span>Toronto ON</span>
               </div>
             </div>
-            <ul class="collapsed-bullets timeline-bullets space-y-2">
+            <div class="timeline-details">
+              <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
                 <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
               </ul>
-            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-              Show more
-              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-            </button>
-            <div class="accordion-content hidden pt-3">
-              <ul class="expanded-bullets timeline-bullets space-y-2">
-                <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
-                <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
-                <li>Conducted technical and behavioral interviews and mentored new hires.</li>
-              </ul>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">GCP PubSub</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Streaming</span>
+              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+                Show more
+                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+              </button>
+              <div class="accordion-content hidden pt-3">
+                <ul class="expanded-bullets timeline-bullets space-y-2">
+                  <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
+                  <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
+                  <li>Conducted technical and behavioral interviews and mentored new hires.</li>
+                </ul>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">GCP PubSub</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Streaming</span>
+                </div>
               </div>
             </div>
           </article>
@@ -428,25 +441,27 @@
                 <span>Toronto ON</span>
               </div>
             </div>
-            <ul class="collapsed-bullets timeline-bullets space-y-2">
+            <div class="timeline-details">
+              <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
                 <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
               </ul>
-            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-              Show more
-              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-            </button>
-            <div class="accordion-content hidden pt-3">
-              <ul class="expanded-bullets timeline-bullets space-y-2">
-                <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
-                <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
-                <li>Designed a Go marketplace handler that enabled a new product launch and seamless sales integrations across verticals.</li>
-              </ul>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Prometheus</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Grafana</span>
+              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+                Show more
+                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+              </button>
+              <div class="accordion-content hidden pt-3">
+                <ul class="expanded-bullets timeline-bullets space-y-2">
+                  <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
+                  <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
+                  <li>Designed a Go marketplace handler that enabled a new product launch and seamless sales integrations across verticals.</li>
+                </ul>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Prometheus</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Grafana</span>
+                </div>
               </div>
             </div>
           </article>
@@ -462,24 +477,26 @@
                 <span>Markham ON</span>
               </div>
             </div>
-            <ul class="collapsed-bullets timeline-bullets space-y-2">
+            <div class="timeline-details">
+              <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
                 <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
               </ul>
-            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-              Show more
-              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-            </button>
-            <div class="accordion-content hidden pt-3">
-              <ul class="expanded-bullets timeline-bullets space-y-2">
-                <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
-                <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
-                <li>Provided security guidance to the team, ensuring best practices in architecture and software design.</li>
-              </ul>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">NodeJS</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">ChatOps</span>
+              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+                Show more
+                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+              </button>
+              <div class="accordion-content hidden pt-3">
+                <ul class="expanded-bullets timeline-bullets space-y-2">
+                  <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
+                  <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
+                  <li>Provided security guidance to the team, ensuring best practices in architecture and software design.</li>
+                </ul>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">NodeJS</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">ChatOps</span>
+                </div>
               </div>
             </div>
           </article>
@@ -495,24 +512,26 @@
                 <span>Markham ON</span>
               </div>
             </div>
-            <ul class="collapsed-bullets timeline-bullets space-y-2">
+            <div class="timeline-details">
+              <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
                 <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
               </ul>
-            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-              Show more
-              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-            </button>
-            <div class="accordion-content hidden pt-3">
-              <ul class="expanded-bullets timeline-bullets space-y-2">
-                <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
-                <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
-                <li>Defined and executed performance testing, leading to an overall 20% performance enhancement.</li>
-              </ul>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Java</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Spring</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Performance</span>
+              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+                Show more
+                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+              </button>
+              <div class="accordion-content hidden pt-3">
+                <ul class="expanded-bullets timeline-bullets space-y-2">
+                  <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
+                  <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
+                  <li>Defined and executed performance testing, leading to an overall 20% performance enhancement.</li>
+                </ul>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Java</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Spring</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Performance</span>
+                </div>
               </div>
             </div>
           </article>
@@ -528,21 +547,23 @@
                 <span>Markham ON</span>
               </div>
             </div>
-            <ul class="collapsed-bullets timeline-bullets space-y-2">
+            <div class="timeline-details">
+              <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
               </ul>
-            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-              Show more
-              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-            </button>
-            <div class="accordion-content hidden pt-3">
-              <ul class="expanded-bullets timeline-bullets space-y-2">
-                <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
-              </ul>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Angular</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Dashboards</span>
+              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+                Show more
+                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+              </button>
+              <div class="accordion-content hidden pt-3">
+                <ul class="expanded-bullets timeline-bullets space-y-2">
+                  <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
+                </ul>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Angular</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Dashboards</span>
+                </div>
               </div>
             </div>
           </article>

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
             <a class="focus-ring hover:text-white transition" href="https://linkedin.com/in/alisaleemh/" target="_blank" rel="noreferrer" aria-label="LinkedIn">
               <i class="fa-brands fa-linkedin"></i>
             </a>
-            <a class="focus-ring hover:text-white transition" href="mailto:ali.s1995@gmail.com" aria-label="Email">
+            <a class="focus-ring hover:text-white transition" href="mailto:ahussain.ca5@gmail.com" aria-label="Email">
               <i class="fa-solid fa-envelope"></i>
             </a>
           </div>
@@ -199,7 +199,7 @@
             <span class="text-sm">Go</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="languages">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/java/94a3b8" alt="Java" />
+            <img class="skill-logo" src="https://cdn.simpleicons.org/openjdk/94a3b8" alt="Java" />
             <span class="text-sm">Java</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="languages">
@@ -210,10 +210,6 @@
             <img class="skill-logo" src="https://cdn.simpleicons.org/python/94a3b8" alt="Python" />
             <span class="text-sm">Python</span>
           </div>
-          <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="languages">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/nodedotjs/94a3b8" alt="NodeJS" />
-            <span class="text-sm">NodeJS</span>
-          </div>
 
           <!-- Frameworks -->
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="frameworks">
@@ -223,14 +219,6 @@
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="frameworks">
             <img class="skill-logo" src="https://cdn.simpleicons.org/angular/94a3b8" alt="Angular" />
             <span class="text-sm">Angular</span>
-          </div>
-          <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="frameworks">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/flask/94a3b8" alt="Flask" />
-            <span class="text-sm">Flask</span>
-          </div>
-          <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="frameworks">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/nodedotjs/94a3b8" alt="NodeJS" />
-            <span class="text-sm">NodeJS</span>
           </div>
 
           <!-- Tools -->
@@ -243,10 +231,6 @@
             <span class="text-sm">Docker</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="tools">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/jenkins/94a3b8" alt="Jenkins" />
-            <span class="text-sm">Jenkins</span>
-          </div>
-          <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="tools">
             <img class="skill-logo" src="https://cdn.simpleicons.org/grafana/94a3b8" alt="Grafana" />
             <span class="text-sm">Grafana</span>
           </div>
@@ -255,15 +239,11 @@
             <span class="text-sm">Prometheus</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="tools">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/newrelic/94a3b8" alt="New Relic" />
-            <span class="text-sm">New Relic</span>
-          </div>
-          <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="tools">
             <img class="skill-logo" src="https://cdn.simpleicons.org/terraform/94a3b8" alt="Terraform" />
             <span class="text-sm">Terraform</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="tools">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/crossplane/94a3b8" alt="Crossplane" />
+            <img class="skill-logo" src="https://raw.githubusercontent.com/cncf/artwork/main/projects/crossplane/icon/color/crossplane-icon-color.svg" alt="Crossplane" />
             <span class="text-sm">Crossplane</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="tools">
@@ -289,7 +269,7 @@
             <span class="text-sm">Snowflake</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="databases">
-            <img class="skill-logo" src="https://cdn.simpleicons.org/amazondynamodb/94a3b8" alt="DynamoDB" />
+            <img class="skill-logo" src="https://api.iconify.design/simple-icons:amazondynamodb.svg?color=%2394a3b8" alt="DynamoDB" />
             <span class="text-sm">DynamoDB</span>
           </div>
           <div class="skill-item chip flex items-center gap-3 rounded-xl px-4 py-3 transition" data-category="databases">
@@ -308,6 +288,38 @@
           <p class="text-sm text-slate-400">Condensed timeline with expandable details.</p>
         </div>
         <div class="space-y-4">
+          <!-- Cerebras Systems -->
+          <article class="experience-card rounded-2xl p-5 shadow-soft">
+            <div class="flex flex-col gap-3">
+              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <div>
+                  <h3 class="text-base font-semibold text-slate-100">Senior Software Engineer</h3>
+                  <p class="text-sm text-slate-400">Cerebras Systems · Toronto ON</p>
+                </div>
+                <p class="text-sm text-slate-400">Feb 2025 – Present</p>
+              </div>
+              <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
+                <li>Maintained and extended Kubernetes-style control planes for AI supercomputer clusters, building custom controllers and reconcilers for scheduling, resource allocation, and job lifecycles.</li>
+                <li>Improved controller-driven orchestration for placement, retries, and recovery, resolving reconciliation issues during node failures, partial outages, and rolling maintenance.</li>
+              </ul>
+              <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+                Show more
+                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+              </button>
+              <div class="accordion-content hidden pt-3">
+                <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
+                  <li>Maintained and extended Kubernetes-style control planes for AI supercomputer clusters, building custom controllers and reconcilers for scheduling, resource allocation, and job lifecycles.</li>
+                  <li>Improved controller-driven orchestration for placement, retries, and recovery, resolving reconciliation issues during node failures, partial outages, and rolling maintenance.</li>
+                </ul>
+                <div class="mt-3 flex flex-wrap gap-2">
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Controllers</span>
+                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Scheduling</span>
+                </div>
+              </div>
+            </div>
+          </article>
+
           <!-- Censys -->
           <article class="experience-card rounded-2xl p-5 shadow-soft">
             <div class="flex flex-col gap-3">
@@ -316,7 +328,7 @@
                   <h3 class="text-base font-semibold text-slate-100">Senior Software Engineer, Collections</h3>
                   <p class="text-sm text-slate-400">Censys · Toronto ON</p>
                 </div>
-                <p class="text-sm text-slate-400">Nov 2022 – Present</p>
+                <p class="text-sm text-slate-400">Nov 2022 – Feb 2025</p>
               </div>
               <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
                 <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
@@ -487,8 +499,9 @@
               <div>
                 <h3 class="text-sm font-semibold text-slate-100">The University of Texas at Austin</h3>
                 <p class="text-xs text-slate-400">Master of Science (MSc), Computer Science · Specialization: Artificial Intelligence</p>
+                <p class="text-xs text-slate-400">2025 – 2027 (Expected)</p>
               </div>
-              <img src="https://upload.wikimedia.org/wikipedia/en/4/4a/University_of_Texas_at_Austin_logo.svg" alt="University of Texas at Austin logo" class="h-8 w-auto opacity-60 grayscale" />
+              <img src="https://raw.githubusercontent.com/abrelsfo/sportsJSON/master/collegeFootball/logos/texas.png" alt="University of Texas at Austin logo" class="h-8 w-auto opacity-60 grayscale" />
             </div>
           </article>
           <article class="experience-card rounded-2xl p-5 shadow-soft flex flex-col gap-4">
@@ -498,7 +511,7 @@
                 <p class="text-xs text-slate-400">Bachelor of Engineering, Mechatronics (BEng)</p>
                 <p class="text-xs text-slate-400">Toronto ON (2013–2018) · Dean’s List 2014, 2015, 2016</p>
               </div>
-              <img src="https://upload.wikimedia.org/wikipedia/en/9/9e/Toronto_Metropolitan_University_logo.svg" alt="Toronto Metropolitan University logo" class="h-8 w-auto opacity-60 grayscale" />
+              <img src="https://raw.githubusercontent.com/zonekidsyoga/torontomucatwo/main/Login%20-%20Toronto%20Metropolitan%20University%20Central%20Authentication%20Service_files/tmu_logo.svg" alt="Toronto Metropolitan University logo" class="h-8 w-auto opacity-60 grayscale" />
             </div>
           </article>
         </div>
@@ -517,16 +530,12 @@
             <div class="flex items-center justify-between">
               <div class="space-y-1">
                 <p class="text-xs uppercase tracking-[0.2em] text-slate-400">Email</p>
-                <p class="text-sm text-slate-200">ali.s1995@gmail.com</p>
+                <p class="text-sm text-slate-200">ahussain.ca5@gmail.com</p>
               </div>
               <button id="copy-email" class="focus-ring inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs text-slate-200 hover:border-indigo-300/60 hover:text-white transition" aria-label="Copy email to clipboard">
                 <i class="fa-solid fa-copy"></i>
                 Copy
               </button>
-            </div>
-            <div class="flex items-center gap-2 text-sm text-slate-300">
-              <i class="fa-solid fa-phone"></i>
-              <span>+1 647 987 7996</span>
             </div>
           </div>
           <div class="experience-card rounded-2xl p-5 shadow-soft space-y-4">
@@ -591,47 +600,43 @@
     const filterButtons = document.querySelectorAll('.filter-btn');
     const skillItems = document.querySelectorAll('.skill-item');
 
+    const applySkillFilter = (filter) => {
+      gsap.killTweensOf(skillItems);
+      skillItems.forEach((item) => {
+        const match = filter === 'all' || item.dataset.category === filter;
+        item.classList.toggle('hidden', !match);
+        item.style.removeProperty('opacity');
+        item.style.removeProperty('transform');
+      });
+
+      if (!prefersReducedMotion) {
+        const visibleItems = Array.from(skillItems).filter((item) => !item.classList.contains('hidden'));
+        if (visibleItems.length > 0) {
+          gsap.fromTo(
+            visibleItems,
+            { opacity: 0, y: 6 },
+            { opacity: 1, y: 0, duration: 0.25, ease: 'power1.out', stagger: 0.04, overwrite: 'auto' }
+          );
+        }
+      }
+    };
+
     filterButtons.forEach((btn) => {
       btn.addEventListener('click', () => {
         filterButtons.forEach((button) => button.setAttribute('aria-pressed', 'false'));
         btn.setAttribute('aria-pressed', 'true');
-        const filter = btn.dataset.filter;
-
-        skillItems.forEach((item) => {
-          const match = filter === 'all' || item.dataset.category === filter;
-          if (match) {
-            item.classList.remove('hidden');
-          }
-        });
-
-        if (!prefersReducedMotion) {
-          gsap.to(skillItems, {
-            opacity: (i, el) => (filter === 'all' || el.dataset.category === filter ? 1 : 0),
-            y: (i, el) => (filter === 'all' || el.dataset.category === filter ? 0 : 6),
-            duration: 0.3,
-            ease: 'power1.out',
-            onComplete: () => {
-              skillItems.forEach((item) => {
-                const match = filter === 'all' || item.dataset.category === filter;
-                if (!match) item.classList.add('hidden');
-              });
-            },
-          });
-        } else {
-          skillItems.forEach((item) => {
-            const match = filter === 'all' || item.dataset.category === filter;
-            item.classList.toggle('hidden', !match);
-          });
-        }
+        applySkillFilter(btn.dataset.filter);
       });
     });
+
+    applySkillFilter('all');
 
     // Copy email
     document.getElementById('copy-email').addEventListener('click', async () => {
       try {
-        await navigator.clipboard.writeText('ali.s1995@gmail.com');
+        await navigator.clipboard.writeText('ahussain.ca5@gmail.com');
       } catch (error) {
-        window.location.href = 'mailto:ali.s1995@gmail.com';
+        window.location.href = 'mailto:ahussain.ca5@gmail.com';
       }
     });
 

--- a/index.html
+++ b/index.html
@@ -599,17 +599,22 @@
     const skillItems = document.querySelectorAll('.skill-item');
 
     const applySkillFilter = (filter) => {
-      gsap.killTweensOf(skillItems);
+      const canAnimate = typeof gsap !== 'undefined' && !prefersReducedMotion;
+      if (canAnimate) {
+        gsap.killTweensOf(skillItems);
+      }
+
       skillItems.forEach((item) => {
         const match = filter === 'all' || item.dataset.category === filter;
+        item.hidden = !match;
         item.classList.toggle('hidden', !match);
-        item.style.display = match ? '' : 'none';
+        item.style.removeProperty('display');
         item.style.removeProperty('opacity');
         item.style.removeProperty('transform');
       });
 
-      if (!prefersReducedMotion) {
-        const visibleItems = Array.from(skillItems).filter((item) => item.style.display !== 'none');
+      if (canAnimate) {
+        const visibleItems = Array.from(skillItems).filter((item) => !item.hidden);
         if (visibleItems.length > 0) {
           gsap.fromTo(
             visibleItems,

--- a/index.html
+++ b/index.html
@@ -118,14 +118,15 @@
       background: rgba(148, 163, 184, 0.18);
     }
     .timeline-company {
-      font-size: clamp(1.4rem, 1.1rem + 1vw, 2rem);
-      font-weight: 600;
-      color: #f8fafc;
+      font-size: clamp(1.1rem, 1rem + 0.4vw, 1.4rem);
+      font-weight: 500;
+      color: #dbe2f7;
+      letter-spacing: 0.01em;
     }
     .timeline-role {
-      font-size: 1.05rem;
-      font-weight: 500;
-      color: #e2e8f0;
+      font-size: clamp(1.25rem, 1.1rem + 0.8vw, 1.8rem);
+      font-weight: 600;
+      color: #f8fafc;
     }
     .timeline-meta {
       display: flex;

--- a/index.html
+++ b/index.html
@@ -83,6 +83,73 @@
       border: 1px solid rgba(148, 163, 184, 0.18);
       background: rgba(17, 18, 26, 0.7);
     }
+    .timeline {
+      position: relative;
+    }
+    .timeline::before {
+      content: '';
+      position: absolute;
+      top: 0.5rem;
+      bottom: 0.5rem;
+      left: 0.5rem;
+      width: 1px;
+      background: rgba(148, 163, 184, 0.18);
+    }
+    .timeline-item {
+      position: relative;
+      padding-left: 2.75rem;
+    }
+    .timeline-node {
+      position: absolute;
+      left: 0.25rem;
+      top: 1.2rem;
+      width: 0.75rem;
+      height: 0.75rem;
+      border-radius: 999px;
+      background: rgba(129, 140, 248, 0.9);
+      box-shadow: 0 0 0 4px rgba(15, 17, 25, 1);
+    }
+    .timeline-anchor {
+      display: grid;
+      gap: 0.35rem;
+    }
+    .timeline-company {
+      font-size: clamp(1.4rem, 1.1rem + 1vw, 2rem);
+      font-weight: 600;
+      color: #f8fafc;
+    }
+    .timeline-role {
+      font-size: 1.05rem;
+      font-weight: 500;
+      color: #e2e8f0;
+    }
+    .timeline-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      font-size: 0.95rem;
+      color: #cbd5f5;
+    }
+    .timeline-bullets {
+      margin-top: 0.75rem;
+      font-size: 0.95rem;
+      color: #cbd5f5;
+      line-height: 1.6;
+    }
+    @media (max-width: 640px) {
+      .timeline::before {
+        left: 0.3rem;
+      }
+      .timeline-item {
+        padding-left: 2.25rem;
+      }
+      .timeline-node {
+        left: 0.05rem;
+      }
+      .timeline-meta {
+        font-size: 0.9rem;
+      }
+    }
     .accordion-toggle[aria-expanded="true"] .toggle-icon {
       transform: rotate(180deg);
     }
@@ -284,198 +351,198 @@
           <h2 class="text-xl font-semibold text-slate-50">Experience</h2>
           <p class="text-sm text-slate-400">Condensed timeline with expandable details.</p>
         </div>
-        <div class="space-y-4">
+        <div class="timeline space-y-8">
           <!-- Cerebras Systems -->
-          <article class="experience-card rounded-2xl p-5 shadow-soft">
-            <div class="flex flex-col gap-3">
-              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <div>
-                  <h3 class="text-base font-semibold text-slate-100">Senior Software Engineer</h3>
-                  <p class="text-sm text-slate-400">Cerebras Systems · Toronto ON</p>
-                </div>
-                <p class="text-sm text-slate-400">Feb 2025 – Present</p>
+          <article class="timeline-item">
+            <span class="timeline-node" aria-hidden="true"></span>
+            <div class="timeline-anchor">
+              <h3 class="timeline-company">Cerebras Systems</h3>
+              <p class="timeline-role">Senior Software Engineer</p>
+              <div class="timeline-meta">
+                <span>Feb 2025 – Present</span>
+                <span>Toronto ON</span>
               </div>
-              <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
+            </div>
+            <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
                 <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
               </ul>
-              <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
-                  <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
-                  <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
-                </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Controllers</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Scheduling</span>
-                </div>
+            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+              Show more
+              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+            </button>
+            <div class="accordion-content hidden pt-3">
+              <ul class="expanded-bullets timeline-bullets space-y-2">
+                <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
+                <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
+              </ul>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Controllers</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Scheduling</span>
               </div>
             </div>
           </article>
 
           <!-- Censys -->
-          <article class="experience-card rounded-2xl p-5 shadow-soft">
-            <div class="flex flex-col gap-3">
-              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <div>
-                  <h3 class="text-base font-semibold text-slate-100">Senior Software Engineer, Collections</h3>
-                  <p class="text-sm text-slate-400">Censys · Toronto ON</p>
-                </div>
-                <p class="text-sm text-slate-400">Nov 2022 – Feb 2025</p>
+          <article class="timeline-item">
+            <span class="timeline-node" aria-hidden="true"></span>
+            <div class="timeline-anchor">
+              <h3 class="timeline-company">Censys</h3>
+              <p class="timeline-role">Senior Software Engineer, Collections</p>
+              <div class="timeline-meta">
+                <span>Nov 2022 – Feb 2025</span>
+                <span>Toronto ON</span>
               </div>
-              <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
+            </div>
+            <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
                 <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
               </ul>
-              <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
-                  <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
-                  <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
-                  <li>Conducted technical and behavioral interviews and mentored new hires.</li>
-                </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">GCP PubSub</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Streaming</span>
-                </div>
+            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+              Show more
+              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+            </button>
+            <div class="accordion-content hidden pt-3">
+              <ul class="expanded-bullets timeline-bullets space-y-2">
+                <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
+                <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
+                <li>Conducted technical and behavioral interviews and mentored new hires.</li>
+              </ul>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">GCP PubSub</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Streaming</span>
               </div>
             </div>
           </article>
 
           <!-- Nylas -->
-          <article class="experience-card rounded-2xl p-5 shadow-soft">
-            <div class="flex flex-col gap-3">
-              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <div>
-                  <h3 class="text-base font-semibold text-slate-100">Software Engineer, Platform</h3>
-                  <p class="text-sm text-slate-400">Nylas · Toronto ON</p>
-                </div>
-                <p class="text-sm text-slate-400">Oct 2021 – Sep 2022</p>
+          <article class="timeline-item">
+            <span class="timeline-node" aria-hidden="true"></span>
+            <div class="timeline-anchor">
+              <h3 class="timeline-company">Nylas</h3>
+              <p class="timeline-role">Software Engineer, Platform</p>
+              <div class="timeline-meta">
+                <span>Oct 2021 – Sep 2022</span>
+                <span>Toronto ON</span>
               </div>
-              <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
+            </div>
+            <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
                 <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
               </ul>
-              <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
-                  <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
-                  <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
-                  <li>Designed a Go marketplace handler that enabled a new product launch and seamless sales integrations across verticals.</li>
-                </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Prometheus</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Grafana</span>
-                </div>
+            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+              Show more
+              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+            </button>
+            <div class="accordion-content hidden pt-3">
+              <ul class="expanded-bullets timeline-bullets space-y-2">
+                <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
+                <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
+                <li>Designed a Go marketplace handler that enabled a new product launch and seamless sales integrations across verticals.</li>
+              </ul>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Prometheus</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Grafana</span>
               </div>
             </div>
           </article>
 
           <!-- IBM Cloud -->
-          <article class="experience-card rounded-2xl p-5 shadow-soft">
-            <div class="flex flex-col gap-3">
-              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <div>
-                  <h3 class="text-base font-semibold text-slate-100">Software Engineer II, IBM Cloud</h3>
-                  <p class="text-sm text-slate-400">IBM Canada · Markham ON</p>
-                </div>
-                <p class="text-sm text-slate-400">Apr 2020 – Oct 2021</p>
+          <article class="timeline-item">
+            <span class="timeline-node" aria-hidden="true"></span>
+            <div class="timeline-anchor">
+              <h3 class="timeline-company">IBM Canada</h3>
+              <p class="timeline-role">Software Engineer II, IBM Cloud</p>
+              <div class="timeline-meta">
+                <span>Apr 2020 – Oct 2021</span>
+                <span>Markham ON</span>
               </div>
-              <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
+            </div>
+            <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
                 <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
               </ul>
-              <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
-                  <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
-                  <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
-                  <li>Provided security guidance to the team, ensuring best practices in architecture and software design.</li>
-                </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">NodeJS</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">ChatOps</span>
-                </div>
+            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+              Show more
+              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+            </button>
+            <div class="accordion-content hidden pt-3">
+              <ul class="expanded-bullets timeline-bullets space-y-2">
+                <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
+                <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
+                <li>Provided security guidance to the team, ensuring best practices in architecture and software design.</li>
+              </ul>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">NodeJS</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">ChatOps</span>
               </div>
             </div>
           </article>
 
           <!-- IBM DevOps -->
-          <article class="experience-card rounded-2xl p-5 shadow-soft">
-            <div class="flex flex-col gap-3">
-              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <div>
-                  <h3 class="text-base font-semibold text-slate-100">Software Engineer II, DevOps for Enterprise</h3>
-                  <p class="text-sm text-slate-400">IBM Canada · Markham ON</p>
-                </div>
-                <p class="text-sm text-slate-400">May 2018 – Apr 2020</p>
+          <article class="timeline-item">
+            <span class="timeline-node" aria-hidden="true"></span>
+            <div class="timeline-anchor">
+              <h3 class="timeline-company">IBM Canada</h3>
+              <p class="timeline-role">Software Engineer II, DevOps for Enterprise</p>
+              <div class="timeline-meta">
+                <span>May 2018 – Apr 2020</span>
+                <span>Markham ON</span>
               </div>
-              <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
+            </div>
+            <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
                 <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
               </ul>
-              <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
-                  <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
-                  <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
-                  <li>Defined and executed performance testing, leading to an overall 20% performance enhancement.</li>
-                </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Java</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Spring</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Performance</span>
-                </div>
+            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+              Show more
+              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+            </button>
+            <div class="accordion-content hidden pt-3">
+              <ul class="expanded-bullets timeline-bullets space-y-2">
+                <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
+                <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
+                <li>Defined and executed performance testing, leading to an overall 20% performance enhancement.</li>
+              </ul>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Java</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Spring</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Performance</span>
               </div>
             </div>
           </article>
 
           <!-- IBM Intern -->
-          <article class="experience-card rounded-2xl p-5 shadow-soft">
-            <div class="flex flex-col gap-3">
-              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <div>
-                  <h3 class="text-base font-semibold text-slate-100">Software Engineer, Db2 Performance</h3>
-                  <p class="text-sm text-slate-400">IBM Canada · Markham ON</p>
-                </div>
-                <p class="text-sm text-slate-400">May 2016 – Apr 2018</p>
+          <article class="timeline-item">
+            <span class="timeline-node" aria-hidden="true"></span>
+            <div class="timeline-anchor">
+              <h3 class="timeline-company">IBM Canada</h3>
+              <p class="timeline-role">Software Engineer, Db2 Performance</p>
+              <div class="timeline-meta">
+                <span>May 2016 – Apr 2018</span>
+                <span>Markham ON</span>
               </div>
-              <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
+            </div>
+            <ul class="collapsed-bullets timeline-bullets space-y-2">
                 <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
               </ul>
-              <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
-                  <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
-                </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Angular</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Dashboards</span>
-                </div>
+            <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
+              Show more
+              <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+            </button>
+            <div class="accordion-content hidden pt-3">
+              <ul class="expanded-bullets timeline-bullets space-y-2">
+                <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
+              </ul>
+              <div class="mt-3 flex flex-wrap gap-2">
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Angular</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
+                <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Dashboards</span>
               </div>
             </div>
           </article>

--- a/index.html
+++ b/index.html
@@ -603,12 +603,13 @@
       skillItems.forEach((item) => {
         const match = filter === 'all' || item.dataset.category === filter;
         item.classList.toggle('hidden', !match);
+        item.style.display = match ? '' : 'none';
         item.style.removeProperty('opacity');
         item.style.removeProperty('transform');
       });
 
       if (!prefersReducedMotion) {
-        const visibleItems = Array.from(skillItems).filter((item) => !item.classList.contains('hidden'));
+        const visibleItems = Array.from(skillItems).filter((item) => item.style.display !== 'none');
         if (visibleItems.length > 0) {
           gsap.fromTo(
             visibleItems,

--- a/index.html
+++ b/index.html
@@ -458,7 +458,7 @@
             <div class="flex flex-col gap-3">
               <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                 <div>
-                  <h3 class="text-base font-semibold text-slate-100">Software Engineer (Intern), Db2 Performance</h3>
+                  <h3 class="text-base font-semibold text-slate-100">Software Engineer, Db2 Performance</h3>
                   <p class="text-sm text-slate-400">IBM Canada · Markham ON</p>
                 </div>
                 <p class="text-sm text-slate-400">May 2016 – Apr 2018</p>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
           <p class="mono text-sm text-indigo-300/80">Senior Software Engineer</p>
           <h1 class="text-3xl sm:text-4xl lg:text-5xl font-semibold tracking-tight text-slate-50">Ali Hussain</h1>
           <p class="text-slate-300 leading-relaxed max-w-2xl">
-            Designing distributed backend systems for cloud-native security platforms, with a focus on Go, Kubernetes, and high-scale data pipelines.
+            Building AI-focused backend systems and control planes for large-scale training and inference, with deep experience in Go, Kubernetes, and distributed data platforms.
           </p>
           <div class="flex flex-wrap gap-3">
             <a href="#contact" class="focus-ring inline-flex items-center gap-2 rounded-full bg-indigo-500/90 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-400 transition">
@@ -154,8 +154,8 @@
           <div class="experience-card rounded-2xl p-5 shadow-soft">
             <p class="mono text-xs uppercase tracking-[0.2em] text-slate-400">Focus</p>
             <ul class="mt-3 space-y-3 text-sm text-slate-300">
-              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Distributed systems, streaming, and CDC pipelines</li>
-              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Cloud-native platforms on GCP, AWS, and Kubernetes</li>
+              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>AI training & inference platforms with Kubernetes-style control planes</li>
+              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Distributed systems, streaming, and high-scale data pipelines</li>
               <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Operational excellence, observability, and resilient tooling</li>
             </ul>
           </div>
@@ -168,10 +168,18 @@
       <div class="space-y-4 max-w-3xl">
         <h2 class="text-xl font-semibold text-slate-50">About</h2>
         <p class="text-slate-300 leading-relaxed">
-          Senior engineer specializing in backend systems, security data products, and cloud orchestration. Strong track record in leading complex projects from discovery to production.
+          Senior engineer focused on AI platform engineering, backend systems, and cloud orchestration. Currently pursuing a Master of Computer Science in Artificial Intelligence at UT Austin (2025–2027, expected) while building production control planes for AI training and inference.
         </p>
+        <div class="text-slate-300 leading-relaxed space-y-2">
+          <p>Completed coursework:</p>
+          <ul class="list-disc list-inside space-y-1">
+            <li>Deep Learning</li>
+            <li>Advanced Deep Learning</li>
+            <li>Ethics in AI</li>
+          </ul>
+        </div>
         <p class="text-slate-300 leading-relaxed">
-          Looking for: senior or staff software engineering roles leading complex initiatives and mentoring teams.
+          Looking for: senior or staff software engineering roles leading complex AI platform initiatives and mentoring teams.
         </p>
       </div>
     </section>
@@ -299,8 +307,8 @@
                 <p class="text-sm text-slate-400">Feb 2025 – Present</p>
               </div>
               <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
-                <li>Maintained and extended Kubernetes-style control planes for AI supercomputer clusters, building custom controllers and reconcilers for scheduling, resource allocation, and job lifecycles.</li>
-                <li>Improved controller-driven orchestration for placement, retries, and recovery, resolving reconciliation issues during node failures, partial outages, and rolling maintenance.</li>
+                <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
+                <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
               </ul>
               <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
                 Show more
@@ -308,8 +316,8 @@
               </button>
               <div class="accordion-content hidden pt-3">
                 <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
-                  <li>Maintained and extended Kubernetes-style control planes for AI supercomputer clusters, building custom controllers and reconcilers for scheduling, resource allocation, and job lifecycles.</li>
-                  <li>Improved controller-driven orchestration for placement, retries, and recovery, resolving reconciliation issues during node failures, partial outages, and rolling maintenance.</li>
+                  <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
+                  <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
                 </ul>
                 <div class="mt-3 flex flex-wrap gap-2">
                   <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>

--- a/index.html
+++ b/index.html
@@ -88,52 +88,50 @@
     }
     .timeline-item {
       position: relative;
-      display: grid;
-      gap: 1.5rem;
-      grid-template-columns: minmax(220px, 40%) minmax(0, 60%);
+      padding-left: 2.75rem;
     }
     .timeline-node {
       position: absolute;
-      left: 0.5rem;
-      top: 1.15rem;
+      left: 0.6rem;
+      top: 1.6rem;
       width: 0.75rem;
       height: 0.75rem;
       border-radius: 999px;
       background: rgba(129, 140, 248, 0.9);
       box-shadow: 0 0 0 4px rgba(15, 17, 25, 1);
     }
-    .timeline-anchor {
-      position: relative;
-      padding-left: 2.75rem;
-      display: grid;
-      gap: 0.35rem;
+    .timeline-card {
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: 1rem;
+      background: rgba(15, 17, 25, 0.6);
+      transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
     }
-    .timeline-anchor::before {
-      content: '';
-      position: absolute;
-      top: 0.5rem;
-      bottom: 0.5rem;
-      left: 0.85rem;
-      width: 1px;
-      background: rgba(148, 163, 184, 0.18);
+    .timeline-card:hover {
+      transform: translateY(-2px);
+      border-color: rgba(129, 140, 248, 0.3);
+      box-shadow: 0 12px 24px -18px rgba(0, 0, 0, 0.65);
+    }
+    .timeline-card.is-expanded {
+      border-color: rgba(129, 140, 248, 0.35);
+      box-shadow: 0 0 18px rgba(129, 140, 248, 0.15);
     }
     .timeline-company {
-      font-size: clamp(1.1rem, 1rem + 0.4vw, 1.4rem);
-      font-weight: 500;
-      color: #dbe2f7;
+      font-size: clamp(1.35rem, 1.1rem + 0.8vw, 1.9rem);
+      font-weight: 600;
+      color: #f8fafc;
       letter-spacing: 0.01em;
     }
     .timeline-role {
-      font-size: clamp(1.25rem, 1.1rem + 0.8vw, 1.8rem);
-      font-weight: 600;
-      color: #f8fafc;
+      font-size: 1.05rem;
+      font-weight: 500;
+      color: #e2e8f0;
     }
     .timeline-meta {
       display: flex;
       flex-wrap: wrap;
       gap: 0.75rem;
       font-size: 0.95rem;
-      color: #cbd5f5;
+      color: #e2e8f0;
     }
     .timeline-bullets {
       font-size: 0.95rem;
@@ -145,16 +143,10 @@
     }
     @media (max-width: 640px) {
       .timeline-item {
-        grid-template-columns: 1fr;
-      }
-      .timeline-node {
-        left: 0.5rem;
-      }
-      .timeline-anchor {
         padding-left: 2.25rem;
       }
-      .timeline-anchor::before {
-        left: 0.6rem;
+      .timeline-node {
+        left: 0.35rem;
       }
       .timeline-meta {
         font-size: 0.9rem;
@@ -365,32 +357,36 @@
           <!-- Cerebras Systems -->
           <article class="timeline-item">
             <span class="timeline-node" aria-hidden="true"></span>
-            <div class="timeline-anchor">
-              <h3 class="timeline-company">Cerebras Systems</h3>
-              <p class="timeline-role">Senior Software Engineer</p>
-              <div class="timeline-meta">
-                <span>Feb 2025 – Present</span>
-                <span>Toronto ON</span>
+            <div class="timeline-card p-6">
+              <div class="space-y-2">
+                <h3 class="timeline-company">Cerebras Systems</h3>
+                <div class="space-y-1">
+                  <p class="timeline-role">Senior Software Engineer</p>
+                  <div class="timeline-meta">
+                    <span>Feb 2025 – Present</span>
+                    <span>Toronto ON</span>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div class="timeline-details">
-              <ul class="collapsed-bullets timeline-bullets space-y-2">
-                <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
-                <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
-              </ul>
-              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets timeline-bullets space-y-2">
+              <div class="timeline-details mt-4">
+                <ul class="collapsed-bullets timeline-bullets space-y-2">
                   <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
                   <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
                 </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Controllers</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Scheduling</span>
+                <button class="accordion-toggle focus-ring mt-4 flex w-full items-center justify-between rounded-lg border border-white/10 bg-ink-800/50 px-4 py-2 text-xs uppercase tracking-[0.2em] text-indigo-200 hover:border-indigo-400/40 hover:text-white transition" aria-expanded="false">
+                  Show more
+                  <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+                </button>
+                <div class="accordion-content hidden pt-3">
+                  <ul class="expanded-bullets timeline-bullets space-y-2">
+                    <li>Built the scheduling and job submission system for AI training and inference workloads on supercomputer clusters.</li>
+                    <li>Maintained and extended Kubernetes-style control planes, building custom controllers and reconcilers for resource allocation, retries, and job lifecycles.</li>
+                  </ul>
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Kubernetes</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Controllers</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Scheduling</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -399,33 +395,37 @@
           <!-- Censys -->
           <article class="timeline-item">
             <span class="timeline-node" aria-hidden="true"></span>
-            <div class="timeline-anchor">
-              <h3 class="timeline-company">Censys</h3>
-              <p class="timeline-role">Senior Software Engineer, Collections</p>
-              <div class="timeline-meta">
-                <span>Nov 2022 – Feb 2025</span>
-                <span>Toronto ON</span>
+            <div class="timeline-card p-6">
+              <div class="space-y-2">
+                <h3 class="timeline-company">Censys</h3>
+                <div class="space-y-1">
+                  <p class="timeline-role">Senior Software Engineer, Collections</p>
+                  <div class="timeline-meta">
+                    <span>Nov 2022 – Feb 2025</span>
+                    <span>Toronto ON</span>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div class="timeline-details">
-              <ul class="collapsed-bullets timeline-bullets space-y-2">
-                <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
-                <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
-              </ul>
-              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets timeline-bullets space-y-2">
+              <div class="timeline-details mt-4">
+                <ul class="collapsed-bullets timeline-bullets space-y-2">
                   <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
                   <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
-                  <li>Conducted technical and behavioral interviews and mentored new hires.</li>
                 </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">GCP PubSub</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Streaming</span>
+                <button class="accordion-toggle focus-ring mt-4 flex w-full items-center justify-between rounded-lg border border-white/10 bg-ink-800/50 px-4 py-2 text-xs uppercase tracking-[0.2em] text-indigo-200 hover:border-indigo-400/40 hover:text-white transition" aria-expanded="false">
+                  Show more
+                  <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+                </button>
+                <div class="accordion-content hidden pt-3">
+                  <ul class="expanded-bullets timeline-bullets space-y-2">
+                    <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
+                    <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
+                    <li>Conducted technical and behavioral interviews and mentored new hires.</li>
+                  </ul>
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Go</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">GCP PubSub</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Streaming</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -434,34 +434,38 @@
           <!-- Nylas -->
           <article class="timeline-item">
             <span class="timeline-node" aria-hidden="true"></span>
-            <div class="timeline-anchor">
-              <h3 class="timeline-company">Nylas</h3>
-              <p class="timeline-role">Software Engineer, Platform</p>
-              <div class="timeline-meta">
-                <span>Oct 2021 – Sep 2022</span>
-                <span>Toronto ON</span>
+            <div class="timeline-card p-6">
+              <div class="space-y-2">
+                <h3 class="timeline-company">Nylas</h3>
+                <div class="space-y-1">
+                  <p class="timeline-role">Software Engineer, Platform</p>
+                  <div class="timeline-meta">
+                    <span>Oct 2021 – Sep 2022</span>
+                    <span>Toronto ON</span>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div class="timeline-details">
-              <ul class="collapsed-bullets timeline-bullets space-y-2">
-                <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
-                <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
-              </ul>
-              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets timeline-bullets space-y-2">
+              <div class="timeline-details mt-4">
+                <ul class="collapsed-bullets timeline-bullets space-y-2">
                   <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
                   <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
-                  <li>Designed a Go marketplace handler that enabled a new product launch and seamless sales integrations across verticals.</li>
                 </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Kubernetes</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Prometheus</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Grafana</span>
+                <button class="accordion-toggle focus-ring mt-4 flex w-full items-center justify-between rounded-lg border border-white/10 bg-ink-800/50 px-4 py-2 text-xs uppercase tracking-[0.2em] text-indigo-200 hover:border-indigo-400/40 hover:text-white transition" aria-expanded="false">
+                  Show more
+                  <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+                </button>
+                <div class="accordion-content hidden pt-3">
+                  <ul class="expanded-bullets timeline-bullets space-y-2">
+                    <li>Built a Go-based Kubernetes orchestrator to provision microservices on AWS and GCP clusters with Prometheus and Grafana observability.</li>
+                    <li>Developed error propagation flows in the orchestrator, reducing support tickets by 50%.</li>
+                    <li>Designed a Go marketplace handler that enabled a new product launch and seamless sales integrations across verticals.</li>
+                  </ul>
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Go</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Kubernetes</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Prometheus</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Grafana</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -470,33 +474,37 @@
           <!-- IBM Cloud -->
           <article class="timeline-item">
             <span class="timeline-node" aria-hidden="true"></span>
-            <div class="timeline-anchor">
-              <h3 class="timeline-company">IBM Canada</h3>
-              <p class="timeline-role">Software Engineer II, IBM Cloud</p>
-              <div class="timeline-meta">
-                <span>Apr 2020 – Oct 2021</span>
-                <span>Markham ON</span>
+            <div class="timeline-card p-6">
+              <div class="space-y-2">
+                <h3 class="timeline-company">IBM Canada</h3>
+                <div class="space-y-1">
+                  <p class="timeline-role">Software Engineer II, IBM Cloud</p>
+                  <div class="timeline-meta">
+                    <span>Apr 2020 – Oct 2021</span>
+                    <span>Markham ON</span>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div class="timeline-details">
-              <ul class="collapsed-bullets timeline-bullets space-y-2">
-                <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
-                <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
-              </ul>
-              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets timeline-bullets space-y-2">
+              <div class="timeline-details mt-4">
+                <ul class="collapsed-bullets timeline-bullets space-y-2">
                   <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
                   <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
-                  <li>Provided security guidance to the team, ensuring best practices in architecture and software design.</li>
                 </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">NodeJS</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">ChatOps</span>
+                <button class="accordion-toggle focus-ring mt-4 flex w-full items-center justify-between rounded-lg border border-white/10 bg-ink-800/50 px-4 py-2 text-xs uppercase tracking-[0.2em] text-indigo-200 hover:border-indigo-400/40 hover:text-white transition" aria-expanded="false">
+                  Show more
+                  <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+                </button>
+                <div class="accordion-content hidden pt-3">
+                  <ul class="expanded-bullets timeline-bullets space-y-2">
+                    <li>Led design and development of a NodeJS ChatOps bot platform used by IBM Cloud service teams to automate workflows.</li>
+                    <li>Implemented a Go service layer for breakglass scenarios, increasing resilience and uptime.</li>
+                    <li>Provided security guidance to the team, ensuring best practices in architecture and software design.</li>
+                  </ul>
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">NodeJS</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Go</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">ChatOps</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -505,33 +513,37 @@
           <!-- IBM DevOps -->
           <article class="timeline-item">
             <span class="timeline-node" aria-hidden="true"></span>
-            <div class="timeline-anchor">
-              <h3 class="timeline-company">IBM Canada</h3>
-              <p class="timeline-role">Software Engineer II, DevOps for Enterprise</p>
-              <div class="timeline-meta">
-                <span>May 2018 – Apr 2020</span>
-                <span>Markham ON</span>
+            <div class="timeline-card p-6">
+              <div class="space-y-2">
+                <h3 class="timeline-company">IBM Canada</h3>
+                <div class="space-y-1">
+                  <p class="timeline-role">Software Engineer II, DevOps for Enterprise</p>
+                  <div class="timeline-meta">
+                    <span>May 2018 – Apr 2020</span>
+                    <span>Markham ON</span>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div class="timeline-details">
-              <ul class="collapsed-bullets timeline-bullets space-y-2">
-                <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
-                <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
-              </ul>
-              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets timeline-bullets space-y-2">
+              <div class="timeline-details mt-4">
+                <ul class="collapsed-bullets timeline-bullets space-y-2">
                   <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
                   <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
-                  <li>Defined and executed performance testing, leading to an overall 20% performance enhancement.</li>
                 </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Java</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Spring</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Performance</span>
+                <button class="accordion-toggle focus-ring mt-4 flex w-full items-center justify-between rounded-lg border border-white/10 bg-ink-800/50 px-4 py-2 text-xs uppercase tracking-[0.2em] text-indigo-200 hover:border-indigo-400/40 hover:text-white transition" aria-expanded="false">
+                  Show more
+                  <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+                </button>
+                <div class="accordion-content hidden pt-3">
+                  <ul class="expanded-bullets timeline-bullets space-y-2">
+                    <li>Led migration to Java Spring microservices, modernizing legacy systems and reducing latency by 80%.</li>
+                    <li>Implemented a caching layer in Java Spring backend, improving performance by 50%.</li>
+                    <li>Defined and executed performance testing, leading to an overall 20% performance enhancement.</li>
+                  </ul>
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Java</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Spring</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Performance</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -540,30 +552,34 @@
           <!-- IBM Intern -->
           <article class="timeline-item">
             <span class="timeline-node" aria-hidden="true"></span>
-            <div class="timeline-anchor">
-              <h3 class="timeline-company">IBM Canada</h3>
-              <p class="timeline-role">Software Engineer, Db2 Performance</p>
-              <div class="timeline-meta">
-                <span>May 2016 – Apr 2018</span>
-                <span>Markham ON</span>
+            <div class="timeline-card p-6">
+              <div class="space-y-2">
+                <h3 class="timeline-company">IBM Canada</h3>
+                <div class="space-y-1">
+                  <p class="timeline-role">Software Engineer, Db2 Performance</p>
+                  <div class="timeline-meta">
+                    <span>May 2016 – Apr 2018</span>
+                    <span>Markham ON</span>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div class="timeline-details">
-              <ul class="collapsed-bullets timeline-bullets space-y-2">
-                <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
-              </ul>
-              <button class="accordion-toggle focus-ring mt-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
-                Show more
-                <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
-              </button>
-              <div class="accordion-content hidden pt-3">
-                <ul class="expanded-bullets timeline-bullets space-y-2">
+              <div class="timeline-details mt-4">
+                <ul class="collapsed-bullets timeline-bullets space-y-2">
                   <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
                 </ul>
-                <div class="mt-3 flex flex-wrap gap-2">
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Angular</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Go</span>
-                  <span class="chip rounded-full px-3 py-1 text-xs text-slate-300">Dashboards</span>
+                <button class="accordion-toggle focus-ring mt-4 flex w-full items-center justify-between rounded-lg border border-white/10 bg-ink-800/50 px-4 py-2 text-xs uppercase tracking-[0.2em] text-indigo-200 hover:border-indigo-400/40 hover:text-white transition" aria-expanded="false">
+                  Show more
+                  <i class="toggle-icon fa-solid fa-chevron-down text-xs transition"></i>
+                </button>
+                <div class="accordion-content hidden pt-3">
+                  <ul class="expanded-bullets timeline-bullets space-y-2">
+                    <li>Led the development of a new Angular 4 dashboard and Go backend resulting in 10X faster load times and a more maintainable and scalable codebase.</li>
+                  </ul>
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Angular</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Go</span>
+                    <span class="chip rounded-full px-3 py-1 text-xs text-slate-200 bg-ink-800/80">Dashboards</span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -669,15 +685,17 @@
 
     // Accordion
     document.querySelectorAll('.accordion-toggle').forEach((toggle) => {
-      toggle.addEventListener('click', () => {
-        const content = toggle.parentElement.querySelector('.accordion-content');
-        const collapsed = toggle.parentElement.querySelector('.collapsed-bullets');
-        const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-        toggle.setAttribute('aria-expanded', String(!isExpanded));
-        toggle.firstChild.textContent = isExpanded ? 'Show more' : 'Show less';
-        content.classList.toggle('hidden');
-        collapsed.classList.toggle('hidden');
-        if (!prefersReducedMotion) {
+        toggle.addEventListener('click', () => {
+          const content = toggle.parentElement.querySelector('.accordion-content');
+          const collapsed = toggle.parentElement.querySelector('.collapsed-bullets');
+          const card = toggle.closest('.timeline-card');
+          const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+          toggle.setAttribute('aria-expanded', String(!isExpanded));
+          toggle.firstChild.textContent = isExpanded ? 'Show more' : 'Show less';
+          if (card) card.classList.toggle('is-expanded', !isExpanded);
+          content.classList.toggle('hidden');
+          collapsed.classList.toggle('hidden');
+          if (!prefersReducedMotion) {
           gsap.fromTo(content, { opacity: 0, y: -4 }, { opacity: 1, y: 0, duration: 0.3, ease: 'power1.out' });
         }
       });

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
       <div class="space-y-4 max-w-3xl">
         <h2 class="text-xl font-semibold text-slate-50">About</h2>
         <p class="text-slate-300 leading-relaxed">
-          Senior engineer focused on AI platform engineering, backend systems, and cloud orchestration. Currently pursuing a Master of Computer Science in Artificial Intelligence at UT Austin (2025–2027, expected) while building production control planes for AI training and inference.
+          Senior engineer focused on AI platform engineering, backend systems, and cloud orchestration. Experienced in building production control planes for AI training and inference alongside large-scale distributed data platforms.
         </p>
         <p class="text-slate-300 leading-relaxed">
           Looking for: senior or staff software engineering roles leading complex AI platform initiatives and mentoring teams.

--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
               </div>
               <ul class="collapsed-bullets text-sm text-slate-300 space-y-2">
                 <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
-                <li>Led development of a real-time CDC streaming service in Go and GCP PubSub, enabling instant attack surface change detection and replacing nightly batches.</li>
+                <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
               </ul>
               <button class="accordion-toggle focus-ring mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-indigo-300" aria-expanded="false">
                 Show more
@@ -338,7 +338,7 @@
               <div class="accordion-content hidden pt-3">
                 <ul class="expanded-bullets text-sm text-slate-300 space-y-2">
                   <li>Led the Automated Asset Discovery project, automating seed identification for attack surfaces, used by sales demos and mitigating deal risk for a major customer.</li>
-                  <li>Led development of a real-time CDC streaming service in Go and GCP PubSub, enabling instant attack surface change detection and replacing nightly batches.</li>
+                  <li>Delivered a real-time CDC streaming service in Go and GCP PubSub, partnering with a staff engineer on architecture to enable instant attack surface change detection and replace nightly batches.</li>
                   <li>Conducted technical and behavioral interviews and mentored new hires.</li>
                 </ul>
                 <div class="mt-3 flex flex-wrap gap-2">

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
             <p class="mono text-xs uppercase tracking-[0.2em] text-slate-400">Focus</p>
             <ul class="mt-3 space-y-3 text-sm text-slate-300">
               <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>AI training & inference platforms with production-grade control planes</li>
-              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Distributed systems, streaming, and high-scale data pipelines</li>
+              <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Distributed systems, event-driven architectures, and high-scale data pipelines</li>
               <li class="flex items-start gap-3"><span class="text-indigo-300">▹</span>Operational excellence, observability, and resilient tooling</li>
             </ul>
           </div>
@@ -169,9 +169,6 @@
         <h2 class="text-xl font-semibold text-slate-50">About</h2>
         <p class="text-slate-300 leading-relaxed">
           Senior engineer focused on AI platform engineering, backend systems, and cloud orchestration. Experienced in building production control planes for AI training and inference alongside large-scale distributed data platforms.
-        </p>
-        <p class="text-slate-300 leading-relaxed">
-          Looking for: senior or staff software engineering roles leading complex AI platform initiatives and mentoring teams.
         </p>
       </div>
     </section>


### PR DESCRIPTION
### Motivation

- Avoid shipping binary logo files and prevent broken or blocked remote loads by switching to vetted remote logo URLs and removing local PNG assets.
- Ensure the skills filter reliably restores and animates visible items and avoids stuck inline styles from previous animations.
- Add the new Senior Software Engineer role and correct timeline details for existing experience entries. 
- Keep contact information current by updating the displayed email and clipboard behavior.

### Description

- Replaced local education logo images in `index.html` with remote raw GitHub URLs and removed the `assets/logos` PNG files from the repository. 
- Reworked the skills filtering into an `applySkillFilter` helper that calls `gsap.killTweensOf`, clears inline `opacity`/`transform` styles, toggles `hidden` by `data-category`, runs a grouped `gsap.fromTo` animation for visible items, and calls `applySkillFilter('all')` on init. 
- Added a new Cerebras Systems experience article and updated the Censys end date and UT Austin expected dates, plus updated several skill icons (for example, `java` → `openjdk`, `crossplane` → CNCF artwork, `DynamoDB` → Iconify) and removed a few duplicate chips. 
- Updated contact copies and clipboard fallback to use `ahussain.ca5@gmail.com` in the mailto links and `navigator.clipboard` usage.

### Testing

- Started a local static server with `python -m http.server 8000`, which served the site successfully.
- Ran a Playwright script to load `http://127.0.0.1:8000/index.html` and take a screenshot, but the browser crashed with a `SIGSEGV` and the Playwright run failed. 
- No unit tests were added or required for this static site change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695061789e9c83239606869d195649ae)